### PR TITLE
Removed redundant env var access causing KeyError

### DIFF
--- a/handlers/orderHandlers/mockGenerateLabel/app.py
+++ b/handlers/orderHandlers/mockGenerateLabel/app.py
@@ -4,7 +4,6 @@ import time
 import json
 
 client = boto3.client('lambda')
-lambda_func_name = os.environ['REPORT_PROGRESS_LAMBDA']
 
 
 def handler(event, context):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Removed `os.environ` call that was failing because the environment variable wasn't being set. The local variable isn't being used in code thus simply removing it fixes the issue.

```
{
  "errorMessage": "'REPORT_PROGRESS_LAMBDA'",
  "errorType": "KeyError",
  "requestId": "",
  "stackTrace": [
    "  File \"/var/lang/lib/python3.9/importlib/__init__.py\", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n",
    "  File \"<frozen importlib._bootstrap>\", line 1030, in _gcd_import\n",
    "  File \"<frozen importlib._bootstrap>\", line 1007, in _find_and_load\n",
    "  File \"<frozen importlib._bootstrap>\", line 986, in _find_and_load_unlocked\n",
    "  File \"<frozen importlib._bootstrap>\", line 680, in _load_unlocked\n",
    "  File \"<frozen importlib._bootstrap_external>\", line 850, in exec_module\n",
    "  File \"<frozen importlib._bootstrap>\", line 228, in _call_with_frames_removed\n",
    "  File \"/var/task/app.py\", line 7, in <module>\n    lambda_func_name = os.environ['REPORT_PROGRESS_LAMBDA']\n",
    "  File \"/var/lang/lib/python3.9/os.py\", line 679, in __getitem__\n    raise KeyError(key) from None\n"
  ]
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
